### PR TITLE
Remove coverage from tests since it doesn't work

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,5 +4,4 @@ modernize
 multilint
 pygments
 pytest
-pytest-cov
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 configparser==3.5.0       # via flake8
-coverage==4.4.1           # via pytest-cov
 docutils==0.13.1
 enum34==1.1.6             # via flake8
 flake8==3.3.0
@@ -16,6 +15,5 @@ py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0
-pytest-cov==2.5.1
 pytest==3.1.2
 six==1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,3 @@ not_skip = __init__.py
 paths = pytest_flake8dir.py
         setup.py
         test_pytest_flake8dir.py
-
-[tool:pytest]
-addopts = --cov=pytest_flake8dir
-          --cov-report term-missing
-          --cov-fail-under 100


### PR DESCRIPTION
Coverage wasn't happening for import/def lines. Looks like pytest-dev/pytest-cov#117 affects us, I guess the plugin load/execute order is what is breaking it for us.