### PR TITLE
Always create and use setup.cfg

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* A temporary ``setup.cfg`` file is now always created with no options and
+  passed as ``--config``, to avoid flake8 merging in user-specific settings.
+  Use ``make_setup_cfg`` to set the contents of this file.
+
 1.2.0 (2018-02-25)
 ------------------
 

--- a/pytest_flake8dir.py
+++ b/pytest_flake8dir.py
@@ -22,6 +22,7 @@ def flake8dir(tmpdir_factory):
 class Flake8Dir(object):
     def __init__(self, tmpdir):
         self.tmpdir = tmpdir
+        self.make_setup_cfg('[flake8]\n')
 
     def make_py_files(self, *args, **kwargs):
         if len(args) != 0:
@@ -48,6 +49,7 @@ class Flake8Dir(object):
         args = [
             'flake8',
             '--jobs', '1',
+            '--config', 'setup.cfg',
             '.',
         ]
         if extra_args:


### PR DESCRIPTION
This avoids merging in user-specific settings, and stops a warning being triggered in flake8's code for merging multiple config files.