### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 1.3.0 (2018-10-16)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Use **pip**:
 
     pip install pytest-flake8dir
 
-Tested on Python 2.7 and Python 3.6.
+Python 3.4+ supported.
 
 API
 ===

--- a/pytest_flake8dir.py
+++ b/pytest_flake8dir.py
@@ -1,12 +1,9 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+import io
 import sys
 from contextlib import contextmanager
 from textwrap import dedent
 
 import pytest
-import six
 from flake8.main.cli import main as flake8_main
 
 
@@ -91,7 +88,7 @@ def captured_output(stream_name):
     Note: This function and the following ``captured_std*`` are copied
           from CPython's ``test.support`` module."""
     orig_stdout = getattr(sys, stream_name)
-    setattr(sys, stream_name, six.StringIO())
+    setattr(sys, stream_name, io.StringIO())
     try:
         yield getattr(sys, stream_name)
     finally:

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,5 @@
 docutils
 flake8
-modernize
 multilint
 pygments
 pytest
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,21 +6,15 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,7 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max_line_length = 120
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 known_first_party = pytest_flake8dir
 line_length = 120
 multi_line_output = 5

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
@@ -11,7 +7,7 @@ def get_version(filename):
     '''
     Return package version as listed in `__version__` in `filename`.
     '''
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         init_py = fp.read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
@@ -19,10 +15,10 @@ def get_version(filename):
 version = get_version('pytest_flake8dir.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -39,9 +35,8 @@ setup(
     install_requires=[
         'flake8',
         'pytest',
-        'six',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license='ISC License',
     zip_safe=False,
     keywords='pytest, flake8',
@@ -55,8 +50,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test_pytest_flake8dir.py
+++ b/test_pytest_flake8dir.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import flake8
 import pytest
 import six

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,13 @@
 [tox]
 envlist =
-    py{27,36}-codestyle,
-    py{27,36}
+    py3,
+    py3-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
 
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `modernize` and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports, and remove universal wheel building