### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ pytest-flake8dir
 .. image:: https://img.shields.io/pypi/v/pytest-flake8dir.svg
         :target: https://pypi.python.org/pypi/pytest-flake8dir
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 A pytest fixture for testing flake8 plugins.
 
 A quick example:

--- a/pytest_flake8dir.py
+++ b/pytest_flake8dir.py
@@ -4,48 +4,43 @@ from textwrap import dedent
 import pytest
 
 
-__version__ = '2.1.0'
+__version__ = "2.1.0"
 
 
 @pytest.fixture
 def flake8dir(tmpdir_factory):
-    tmpdir = tmpdir_factory.mktemp('flake8dir')
+    tmpdir = tmpdir_factory.mktemp("flake8dir")
     yield Flake8Dir(tmpdir)
 
 
 class Flake8Dir(object):
     def __init__(self, tmpdir):
         self.tmpdir = tmpdir
-        self.make_setup_cfg('[flake8]\n')
+        self.make_setup_cfg("[flake8]\n")
 
     def make_py_files(self, *args, **kwargs):
         if len(args) != 0:
-            raise TypeError('make_py_files takes no positional arguments')
+            raise TypeError("make_py_files takes no positional arguments")
         if len(kwargs) == 0:
-            raise TypeError('make_py_files requires at least one keyword argument')
+            raise TypeError("make_py_files requires at least one keyword argument")
 
         for name, content in kwargs.items():
-            self.make_file(name + '.py', content)
+            self.make_file(name + ".py", content)
 
     def make_example_py(self, content):
         self.make_py_files(example=content)
 
     def make_setup_cfg(self, content):
-        self.make_file('setup.cfg', content)
+        self.make_file("setup.cfg", content)
 
     def make_file(self, filename, content):
         path = self.tmpdir.join(filename)
         path.dirpath().ensure_dir()
-        fixed_content = dedent(content).strip() + '\n'
-        path.write(fixed_content.encode('utf-8'), 'wb')
+        fixed_content = dedent(content).strip() + "\n"
+        path.write(fixed_content.encode("utf-8"), "wb")
 
     def run_flake8(self, extra_args=None):
-        args = [
-            'flake8',
-            '--jobs', '1',
-            '--config', 'setup.cfg',
-            '.',
-        ]
+        args = ["flake8", "--jobs", "1", "--config", "setup.cfg", "."]
         if extra_args:
             args.extend(extra_args)
 
@@ -65,7 +60,7 @@ class Flake8Result(object):
         self.out = out
         self.exit_code = exit_code
 
-        lines = out.strip().split('\n')
-        if lines[-1] == '':
+        lines = out.strip().split("\n")
+        if lines[-1] == "":
             lines = lines[:-1]
         self.out_lines = lines

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,6 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -104,6 +118,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
+flake8-bugbear
 multilint
 pygments
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,16 @@
 [flake8]
-max_line_length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
+include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = pytest_flake8dir
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -4,56 +4,51 @@ from setuptools import setup
 
 
 def get_version(filename):
-    '''
+    """
     Return package version as listed in `__version__` in `filename`.
-    '''
-    with open(filename, 'r') as fp:
+    """
+    with open(filename, "r") as fp:
         init_py = fp.read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
-version = get_version('pytest_flake8dir.py')
+version = get_version("pytest_flake8dir.py")
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='pytest-flake8dir',
+    name="pytest-flake8dir",
     version=version,
-    description='A pytest fixture for testing flake8 plugins.',
-    long_description=readme + '\n\n' + history,
-    author='Adam Johnson',
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/pytest-flake8dir',
-    py_modules=['pytest_flake8dir'],
+    description="A pytest fixture for testing flake8 plugins.",
+    long_description=readme + "\n\n" + history,
+    author="Adam Johnson",
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/pytest-flake8dir",
+    py_modules=["pytest_flake8dir"],
     include_package_data=True,
-    install_requires=[
-        'flake8',
-        'pytest',
-    ],
-    python_requires='>=3.5',
-    license='ISC License',
+    install_requires=["flake8", "pytest"],
+    python_requires=">=3.5",
+    license="ISC License",
     zip_safe=False,
-    keywords='pytest, flake8',
-    entry_points={
-        'pytest11': ['flake8dir = pytest_flake8dir'],
-    },
+    keywords="pytest, flake8",
+    entry_points={"pytest11": ["flake8dir = pytest_flake8dir"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_pytest_flake8dir.py
+++ b/test_pytest_flake8dir.py
@@ -4,12 +4,14 @@ import six
 
 
 def test_make_py_files_single(flake8dir):
-    flake8dir.make_py_files(example="""
+    flake8dir.make_py_files(
+        example="""
         x  = 1
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:2: E221 multiple spaces before operator'
+        "./example.py:1:2: E221 multiple spaces before operator"
     ]
     assert result.exit_code == 1
 
@@ -21,44 +23,53 @@ def test_make_py_files_double(flake8dir):
         """,
         example2="""
             y  = 2
-        """
+        """,
     )
     result = flake8dir.run_flake8()
     assert set(result.out_lines) == {
-        './example1.py:1:2: E221 multiple spaces before operator',
-        './example2.py:1:2: E221 multiple spaces before operator',
+        "./example1.py:1:2: E221 multiple spaces before operator",
+        "./example2.py:1:2: E221 multiple spaces before operator",
     }
 
 
 def test_make_py_files_no_positional_args(flake8dir):
     with pytest.raises(TypeError) as excinfo:
-        flake8dir.make_py_files(1, example="""
+        flake8dir.make_py_files(
+            1,
+            example="""
             x  = 1
-        """)
-    assert 'make_py_files takes no positional arguments' in six.text_type(excinfo.value)
+        """,
+        )
+    assert "make_py_files takes no positional arguments" in six.text_type(excinfo.value)
 
 
 def test_make_py_files_requires_at_least_one_kwarg(flake8dir):
     with pytest.raises(TypeError) as excinfo:
         flake8dir.make_py_files()
-    assert 'make_py_files requires at least one keyword argument' in six.text_type(excinfo.value)
+    assert "make_py_files requires at least one keyword argument" in six.text_type(
+        excinfo.value
+    )
 
 
 def test_make_example_py(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         x  = 1
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './example.py:1:2: E221 multiple spaces before operator'
+        "./example.py:1:2: E221 multiple spaces before operator"
     ]
 
 
 def test_make_setup_cfg(flake8dir):
-    flake8dir.make_setup_cfg("""
+    flake8dir.make_setup_cfg(
+        """
         [flake8]
         ignore = E221
-    """)
+    """
+    )
     flake8dir.make_py_files(
         example="""
         x  = 1
@@ -69,12 +80,15 @@ def test_make_setup_cfg(flake8dir):
 
 
 def test_make_file(flake8dir):
-    flake8dir.make_file('myexample.py', """
+    flake8dir.make_file(
+        "myexample.py",
+        """
         x  = 1
-    """)
+    """,
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        './myexample.py:1:2: E221 multiple spaces before operator'
+        "./myexample.py:1:2: E221 multiple spaces before operator"
     ]
 
 
@@ -84,14 +98,14 @@ def test_extra_args(flake8dir):
         x  = 1
         """
     )
-    result = flake8dir.run_flake8(extra_args=['--ignore', 'E221'])
+    result = flake8dir.run_flake8(extra_args=["--ignore", "E221"])
     assert result.out_lines == []
 
 
 def test_extra_args_version(flake8dir):
-    result = flake8dir.run_flake8(extra_args=['--version'])
+    result = flake8dir.run_flake8(extra_args=["--version"])
     assert len(result.out_lines) == 1
-    assert result.out_lines[0].startswith(flake8.__version__ + ' ')
+    assert result.out_lines[0].startswith(flake8.__version__ + " ")
     assert result.exit_code == 0
 
 
@@ -101,4 +115,4 @@ def test_separate_tmpdir(flake8dir, tmpdir):
         x  = 1
         """
     )
-    assert not tmpdir.join('example.py').check()
+    assert not tmpdir.join("example.py").check()


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge