### PR TITLE
Use sys.executable to invoke flake8

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Use sys.executable to invoke flake8. This ensures that we run the flake8
+  installed to match the current interpreter, in multi-interpreter
+  environments.
+
 2.3.0 (2020-12-13)
 ------------------
 

--- a/src/pytest_flake8dir.py
+++ b/src/pytest_flake8dir.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest
@@ -37,7 +38,16 @@ class Flake8Dir:
         path.write(fixed_content.encode("utf-8"), "wb")
 
     def run_flake8(self, extra_args=None):
-        args = ["flake8", "--jobs", "1", "--config", "setup.cfg", "."]
+        args = [
+            sys.executable,
+            "-m",
+            "flake8",
+            "--jobs",
+            "1",
+            "--config",
+            "setup.cfg",
+            ".",
+        ]
         if extra_args:
             args.extend(extra_args)
 


### PR DESCRIPTION
This ensures that we run the flake8 installed to match the current interpreter, in multi-interpreter environments.
