### PR TITLE
Drop *args from make_py_files signature

### DIFF
--- a/src/pytest_flake8dir.py
+++ b/src/pytest_flake8dir.py
@@ -16,9 +16,7 @@ class Flake8Dir:
         self.tmpdir = tmpdir
         self.make_setup_cfg("[flake8]\n")
 
-    def make_py_files(self, *args, **kwargs):
-        if len(args) != 0:
-            raise TypeError("make_py_files takes no positional arguments")
+    def make_py_files(self, **kwargs):
         if len(kwargs) == 0:
             raise TypeError("make_py_files requires at least one keyword argument")
 

--- a/tests/test_pytest_flake8dir.py
+++ b/tests/test_pytest_flake8dir.py
@@ -31,17 +31,6 @@ def test_make_py_files_double(flake8dir):
     }
 
 
-def test_make_py_files_no_positional_args(flake8dir):
-    with pytest.raises(TypeError) as excinfo:
-        flake8dir.make_py_files(
-            1,
-            example="""
-            x  = 1
-        """,
-        )
-    assert "make_py_files takes no positional arguments" in str(excinfo.value)
-
-
 def test_make_py_files_requires_at_least_one_kwarg(flake8dir):
     with pytest.raises(TypeError) as excinfo:
         flake8dir.make_py_files()


### PR DESCRIPTION
Python will error for us if any positional arguments are passed.